### PR TITLE
pass through index parameter to  get_table_rows

### DIFF
--- a/src/eosjs-jsonrpc.ts
+++ b/src/eosjs-jsonrpc.ts
@@ -146,6 +146,7 @@ export default class JsonRpc implements AuthorityProvider, AbiProvider {
         limit = 10,
         reverse = false,
         show_payer = false,
+        index = "primary"
      }: any): Promise<any> {
         return await this.fetch(
             "/v1/chain/get_table_rows", {
@@ -161,6 +162,7 @@ export default class JsonRpc implements AuthorityProvider, AbiProvider {
                 limit,
                 reverse,
                 show_payer,
+                index
             });
     }
 


### PR DESCRIPTION
Без параметра index не работает запрос get_table_rows и возвращает ошибку 500